### PR TITLE
Fix dirname assignment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,12 @@ on:
 jobs:
   luacheck:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
-    -
-      name: Setup Lua
-      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -26,6 +25,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     strategy:
       matrix:
         lua-version:
@@ -36,13 +37,13 @@ jobs:
           - "lj-v2.1:latest"
     steps:
     -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
+    -
       name: Checkout
       uses: actions/checkout@v2
-    -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: mah0x211/setup-lua@v1
-      with:
-        versions: ${{ matrix.lua-version }}
     -
       name: Install
       run: |

--- a/lib/filesystem.lua
+++ b/lib/filesystem.lua
@@ -154,7 +154,10 @@ local function getstat(pathname)
     info.realpath = rpath
     info.basename = match(rpath, '([^/]+)/*$') or '.'
     info.pathname = trim_cwd(rpath)
-    info.dirname = match(info.pathname, '^(.+)/[^/]*$') or '/'
+    info.dirname = match(info.pathname, '^(.+)/[^/]*$')
+    if not info.dirname then
+        info.dirname = sub(info.pathname, 1, 1) == '/' and '/' or '.'
+    end
 
     return info
 end


### PR DESCRIPTION
This pull request updates the test workflow to use a containerized Lua environment and improves the robustness of directory name extraction in `filesystem.lua`. The main changes are grouped into workflow improvements and code robustness enhancements.

**Workflow improvements:**

* Updated `.github/workflows/test.yml` to run tests inside the `ghcr.io/mah0x211/lua-ci:latest` container, ensuring a consistent and reproducible environment for all test jobs.
* Replaced the `setup-lua` action with an explicit step to switch Lua versions using `lenv`, simplifying Lua version management and aligning it with the containerized setup.

**Code robustness:**

* Improved the `getstat` function in `lib/filesystem.lua` to handle cases where the directory name cannot be extracted, defaulting to `'/'` for absolute paths or `'.'` for relative paths, making the function more reliable.