### PR TITLE
Clean up #include directives in src/

### DIFF
--- a/src/chdir.c
+++ b/src/chdir.c
@@ -21,10 +21,9 @@
  */
 
 #include <errno.h>
-#include <string.h>
 #include <unistd.h>
 // lua
-#include <lua_errno.h>
+#include "lua_errno.h"
 
 static int chdir_lua(lua_State *L)
 {

--- a/src/close.c
+++ b/src/close.c
@@ -22,7 +22,11 @@
 #include <errno.h>
 #include <unistd.h>
 // lua
-#include <lua_errno.h>
+#include <lauxlib.h>
+#include <lua.h>
+// external library
+#include "lauxhlib.h"
+#include "lua_errno.h"
 
 static int close_lua(lua_State *L)
 {

--- a/src/fstat.c
+++ b/src/fstat.c
@@ -23,12 +23,15 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 // lua
-#include <lua_errno.h>
+#include <lauxlib.h>
+#include <lua.h>
+// external library
+#include "lauxhlib.h"
+#include "lua_errno.h"
 
 static int fstat_lua(lua_State *L)
 {

--- a/src/getpid.c
+++ b/src/getpid.c
@@ -23,7 +23,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 // lua
-#include <lauxlib.h>
 #include <lualib.h>
 
 static int getpid_lua(lua_State *L)

--- a/src/readdir.c
+++ b/src/readdir.c
@@ -22,12 +22,11 @@
 
 #include <dirent.h>
 #include <errno.h>
-#include <sys/types.h>
 // lua
 #include <lauxlib.h>
 #include <lualib.h>
 // lua module
-#include <lua_errno.h>
+#include "lua_errno.h"
 
 static int readdir_lua(lua_State *L)
 {

--- a/src/realpath.c
+++ b/src/realpath.c
@@ -20,12 +20,16 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
-// lua
+#include <errno.h>
 #include <limits.h>
-#include <lualib.h>
 #include <stdlib.h>
+#include <unistd.h>
 // lua
-#include <lua_errno.h>
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+// external library
+#include "lua_errno.h"
 
 static size_t REALPATH_BUFSIZ = PATH_MAX;
 static char *REALPATH_BUF     = NULL;

--- a/src/select.c
+++ b/src/select.c
@@ -21,9 +21,6 @@
  */
 #include <lauxlib.h>
 #include <lualib.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
 
 static int len_lua(lua_State *L)
 {

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -22,7 +22,8 @@
 #include <errno.h>
 #include <sys/socket.h>
 // lua
-#include <lua_errno.h>
+#include "lauxhlib.h"
+#include "lua_errno.h"
 
 static int shutdown_lua(lua_State *L)
 {

--- a/src/timer.c
+++ b/src/timer.c
@@ -23,7 +23,6 @@
 #include <lauxlib.h>
 #include <lualib.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
realpath.c was calling pathconf() without including <unistd.h>, which
risks an implicit function declaration on strict compilers. Also
switches non-system library headers (lua_errno.h, lauxhlib.h) from
angle brackets to double quotes per C convention.