### PR TITLE
Add timer elapsed sec method

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,19 @@ local val, fmt, unit = t:elapsed()
 - `fmt:string`: Format string.
 - `unit:string`: Unit string.
 
+### sec = t:elapsed_sec()
+
+Returns the time elapsed since the last `start()` as fractional seconds
+without stopping the timer.
+
+```lua
+local sec = t:elapsed_sec()
+```
+
+**Returns**
+
+- `sec:number`: Elapsed time in seconds.
+
 ### val, fmt, unit = t:total()
 
 Returns the total accumulated time across all `start()`/`stop()` intervals.

--- a/src/timer.c
+++ b/src/timer.c
@@ -27,6 +27,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#define NSEC_IN_SEC 1000000000
+
 #if defined(__APPLE__)
 # include <mach/mach.h>
 # include <mach/mach_time.h>
@@ -41,8 +43,8 @@ static inline int getnsec_ex(struct timespec *ts)
     }
 
     ns          = mach_absolute_time() * tbinfo.numer / tbinfo.denom;
-    ts->tv_sec  = ns / 1000000000;
-    ts->tv_nsec = ns - (ts->tv_sec * 1000000000);
+    ts->tv_sec  = ns / NSEC_IN_SEC;
+    ts->tv_nsec = ns - (ts->tv_sec * NSEC_IN_SEC);
     return 0;
 }
 
@@ -63,7 +65,7 @@ static inline int getnsec(uint64_t *ns)
         return -1;
     }
 
-    *ns = (uint64_t)ts.tv_sec * 1000000000 + (uint64_t)ts.tv_nsec;
+    *ns = (uint64_t)ts.tv_sec * NSEC_IN_SEC + (uint64_t)ts.tv_nsec;
     return 0;
 }
 
@@ -110,7 +112,7 @@ static int nsec2utime(lua_State *L, uint64_t ns)
     return 3;
 }
 
-static int elapsed_lua(lua_State *L)
+static int get_elapsed_lua(lua_State *L, int in_sec)
 {
     testcase_timer_t *t =
         (testcase_timer_t *)luaL_checkudata(L, 1, TESTCASE_TIMER_MT);
@@ -120,9 +122,24 @@ static int elapsed_lua(lua_State *L)
         lua_pushnil(L);
         lua_pushstring(L, strerror(errno));
         return 2;
+    } else if (in_sec) {
+        // push elapsed time in seconds
+        lua_pushnumber(L, (double)(ns - t->start) / NSEC_IN_SEC);
+        return 1;
     }
 
+    // push elapsed time in appropriate unit (ns, us, ms, s, min)
     return nsec2utime(L, ns - t->start);
+}
+
+static int elapsed_lua(lua_State *L)
+{
+    return get_elapsed_lua(L, 0);
+}
+
+static int elapsed_sec_lua(lua_State *L)
+{
+    return get_elapsed_lua(L, 1);
 }
 
 static int stop_lua(lua_State *L)
@@ -206,7 +223,7 @@ static int sleep_lua(lua_State *L)
     struct timespec ts = {
         .tv_sec = sec,
     };
-    ts.tv_nsec = (sec - ts.tv_sec) * 1000000000;
+    ts.tv_nsec = (sec - ts.tv_sec) * NSEC_IN_SEC;
 
     nanosleep(&ts, NULL);
 
@@ -222,7 +239,7 @@ static int nanotime_lua(lua_State *L)
         lua_pushstring(L, strerror(errno));
         return 2;
     }
-    lua_pushnumber(L, (double)ts.tv_sec + ((double)ts.tv_nsec / 1000000000));
+    lua_pushnumber(L, (double)ts.tv_sec + ((double)ts.tv_nsec / NSEC_IN_SEC));
 
     return 1;
 }
@@ -236,12 +253,13 @@ LUALIB_API int luaopen_testcase_timer(lua_State *L)
             {NULL,         NULL        }
         };
         struct luaL_Reg method[] = {
-            {"reset",   reset_lua  },
-            {"total",   total_lua  },
-            {"start",   start_lua  },
-            {"stop",    stop_lua   },
-            {"elapsed", elapsed_lua},
-            {NULL,      NULL       }
+            {"reset",       reset_lua      },
+            {"total",       total_lua      },
+            {"start",       start_lua      },
+            {"stop",        stop_lua       },
+            {"elapsed",     elapsed_lua    },
+            {"elapsed_sec", elapsed_sec_lua},
+            {NULL,          NULL           }
         };
         struct luaL_Reg *ptr = mmethod;
 

--- a/test/timer_test.lua
+++ b/test/timer_test.lua
@@ -107,9 +107,33 @@ local function test_stop_total_reset()
     assert.equal(tunit, 'ns')
 end
 
+local function test_elapsed_sec()
+    local t = timer.new()
+    t:start()
+    -- sleep 60ms
+    timer.sleep(0.06)
+
+    -- test that timer:elapsed_sec() returns elapsed time in seconds as a number
+    local v = assert(t:elapsed_sec())
+    assert.is_unsigned(v)
+    assert.is_true(0.05 < v and v < 0.1)
+
+    -- test that the elapsed time increases
+    local prev = v
+    v = assert(t:elapsed_sec())
+    assert.greater(v, prev)
+
+    -- test that after start, elapsed_sec returns a smaller value
+    prev = v
+    assert(t:start())
+    v = assert(t:elapsed_sec())
+    assert.less(v, prev)
+end
+
 test_usleep()
 test_sleep()
 test_new()
 test_start()
 test_elapsed()
+test_elapsed_sec()
 test_stop_total_reset()


### PR DESCRIPTION
This pull request adds a new method to the timer API for retrieving the elapsed time in fractional seconds, and refactors the codebase to use a named constant for nanoseconds per second (`NSEC_IN_SEC`). It also includes corresponding documentation and test updates.

**New feature:**
- Added `elapsed_sec()` method to the timer API, which returns the elapsed time since the last `start()` as a fractional number of seconds without stopping the timer. This is now available in both the C implementation and documented in `README.md`. [[1]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aL113-R115) [[2]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aR261) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R796-R808) [[4]](diffhunk://#diff-f2dcd81088dbcbd6cdc9b4aac8ee0ab14409a39d5050b97050dbb2487cf643b2R110-R138)

**Codebase consistency and refactoring:**
- Introduced `NSEC_IN_SEC` constant and replaced all hardcoded `1000000000` values with this constant throughout `src/timer.c` for improved readability and maintainability. [[1]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aR30-R31) [[2]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aL44-R47) [[3]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aL66-R68) [[4]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aL209-R226) [[5]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aL225-R242)

**Testing:**
- Added a new test case in `test/timer_test.lua` to verify the behavior of the new `elapsed_sec()` method, including checks for increasing values and reset after `start()`.