### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
         luacheck .
 
   test:
+    needs: luacheck
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/mah0x211/lua-ci:latest
@@ -58,7 +61,9 @@ jobs:
         lua ./test/testall.lua
     -
       name: Upload lua coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        use_oidc: true
+        disable_search: true
+        files: ./luacov.report.out
         flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
     -
       name: Install
       run: |
-        luarocks make
+        TESTCASE_COVERAGE=1 luarocks make
     -
       name: Install Tools
       run: |
@@ -60,10 +60,14 @@ jobs:
       run: |
         lua ./test/testall.lua
     -
+      name: Generate C coverage report
+      run: |
+        sh ./covgen.sh
+    -
       name: Upload lua coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
         use_oidc: true
         disable_search: true
-        files: ./luacov.report.out
+        files: ./luacov.report.out, ./coverage/lcov.info
         flags: unittests

--- a/covgen.sh
+++ b/covgen.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+set -ex
+
+mkdir -p ./coverage
+lcov -c -d ./src -o coverage/lcov.info.all
+lcov -r coverage/lcov.info.all '*/include/*' -o coverage/lcov.info
+# genhtml -o coverage/html coverage/lcov.info

--- a/rockspecs/testcase-scm-1.rockspec
+++ b/rockspecs/testcase-scm-1.rockspec
@@ -1,3 +1,4 @@
+rockspec_format = "3.0"
 package = "testcase"
 version = "scm-1"
 source = {
@@ -15,8 +16,23 @@ dependencies = {
     "error >= 0.15.1",
     "errno >= 0.4.0",
 }
+build_dependencies = {
+    "luarocks-build-hooks >= 0.7.0",
+}
 build = {
-    type = "builtin",
+    type = "hooks",
+    before_build = {
+        "$(extra-vars)",
+    },
+    extra_variables = {
+        CFLAGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
+    },
+    conditional_variables = {
+        TESTCASE_COVERAGE = {
+            CFLAGS = "--coverage",
+            LIBFLAG = "--coverage",
+        },
+    },
     install = {
         bin = {
             testcase = "bin/testcase.lua",
@@ -34,17 +50,53 @@ build = {
         ["testcase.registry"] = "lib/registry.lua",
         ["testcase.runner"] = "lib/runner.lua",
         ["testcase.trim"] = "lib/trim.lua",
-        ["testcase.chdir"] = "src/chdir.c",
-        ["testcase.close"] = "src/close.c",
+        ["testcase.chdir"] = {
+            sources = "src/chdir.c",
+            incdirs = {
+                "$(DEP_ERRNO_INCDIR)",
+                "$(DEP_ERROR_INCDIR)",
+            },
+        },
+        ["testcase.close"] = {
+            sources = "src/close.c",
+            incdirs = {
+                "$(DEP_ERRNO_INCDIR)",
+                "$(DEP_ERROR_INCDIR)",
+            },
+        },
         ["testcase.fork"] = "src/fork.c",
-        ["testcase.fstat"] = "src/fstat.c",
+        ["testcase.fstat"] = {
+            sources = "src/fstat.c",
+            incdirs = {
+                "$(DEP_ERRNO_INCDIR)",
+                "$(DEP_ERROR_INCDIR)",
+            },
+        },
         ["testcase.getpid"] = "src/getpid.c",
         ["testcase.nosigchld"] = "src/nosigchld.c",
         ["testcase.nosigpipe"] = "src/nosigpipe.c",
-        ["testcase.readdir"] = "src/readdir.c",
-        ["testcase.realpath"] = "src/realpath.c",
+        ["testcase.readdir"] = {
+            sources = "src/readdir.c",
+            incdirs = {
+                "$(DEP_ERRNO_INCDIR)",
+                "$(DEP_ERROR_INCDIR)",
+            },
+        },
+        ["testcase.realpath"] = {
+            sources = "src/realpath.c",
+            incdirs = {
+                "$(DEP_ERRNO_INCDIR)",
+                "$(DEP_ERROR_INCDIR)",
+            },
+        },
         ["testcase.select"] = "src/select.c",
-        ["testcase.shutdown"] = "src/shutdown.c",
+        ["testcase.shutdown"] = {
+            sources = "src/shutdown.c",
+            incdirs = {
+                "$(DEP_ERRNO_INCDIR)",
+                "$(DEP_ERROR_INCDIR)",
+            },
+        },
         ["testcase.signal"] = "src/signal.c",
         ["testcase.socketpair"] = "src/socketpair.c",
         ["testcase.timer"] = "src/timer.c",

--- a/rockspecs/testcase-scm-1.rockspec
+++ b/rockspecs/testcase-scm-1.rockspec
@@ -12,6 +12,7 @@ description = {
 dependencies = {
     "lua >= 5.1",
     "assert >= 0.5.2",
+    "error >= 0.15.1",
     "errno >= 0.4.0",
 }
 build = {

--- a/src/chdir.c
+++ b/src/chdir.c
@@ -23,6 +23,9 @@
 #include <errno.h>
 #include <unistd.h>
 // lua
+#include <lauxlib.h>
+#include <lua.h>
+// external library
 #include "lua_errno.h"
 
 static int chdir_lua(lua_State *L)

--- a/src/close.c
+++ b/src/close.c
@@ -20,13 +20,25 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 #include <errno.h>
+#include <stdio.h>
 #include <unistd.h>
 // lua
 #include <lauxlib.h>
 #include <lua.h>
+#include <lualib.h>
 // external library
-#include "lauxhlib.h"
 #include "lua_errno.h"
+
+static inline FILE **checkfilep(lua_State *L, int idx)
+{
+#if LUA_VERSION_NUM >= 502
+    luaL_Stream *stream =
+        (luaL_Stream *)luaL_checkudata(L, idx, LUA_FILEHANDLE);
+    return &stream->f;
+#else
+    return (FILE **)luaL_checkudata(L, idx, LUA_FILEHANDLE);
+#endif
+}
 
 static int close_lua(lua_State *L)
 {
@@ -35,7 +47,7 @@ static int close_lua(lua_State *L)
     if (lua_isnumber(L, 1)) {
         fd = luaL_checkinteger(L, 1);
     } else {
-        FILE **fp = lauxh_checkfilep(L, 1);
+        FILE **fp = checkfilep(L, 1);
         if (*fp) {
             fd = fileno(*fp);
         }

--- a/src/fork.c
+++ b/src/fork.c
@@ -29,7 +29,7 @@
 #include <unistd.h>
 // lua
 #include <lauxlib.h>
-#include <lualib.h>
+#include <lua.h>
 
 #define PROC_MT "testcase.process"
 

--- a/src/fork.c
+++ b/src/fork.c
@@ -155,8 +155,9 @@ static int fork_lua(lua_State *L)
 LUALIB_API int luaopen_testcase_fork(lua_State *L)
 {
     struct luaL_Reg mmethod[] = {
-        {"__gc", gc_lua},
-        {NULL,   NULL  }
+        {"__gc",       gc_lua      },
+        {"__tostring", tostring_lua},
+        {NULL,         NULL        }
     };
     struct luaL_Reg method[] = {
         {"pid",      pid_lua     },

--- a/src/fstat.c
+++ b/src/fstat.c
@@ -30,8 +30,19 @@
 #include <lauxlib.h>
 #include <lua.h>
 // external library
-#include "lauxhlib.h"
 #include "lua_errno.h"
+
+static inline void pushint2tbl(lua_State *L, const char *k, lua_Integer v)
+{
+    lua_pushinteger(L, v);
+    lua_setfield(L, -2, k);
+}
+
+static inline void pushstr2tbl(lua_State *L, const char *k, const char *v)
+{
+    lua_pushstring(L, v);
+    lua_setfield(L, -2, k);
+}
 
 static int fstat_lua(lua_State *L)
 {
@@ -42,8 +53,11 @@ static int fstat_lua(lua_State *L)
     char perm[6]     = {0};
 
     // followsymlinks option: default true
-    if (!lauxh_optboolean(L, 2, 1)) {
-        flgs |= O_NOFOLLOW;
+    if (!lua_isnoneornil(L, 2)) {
+        luaL_checktype(L, 2, LUA_TBOOLEAN);
+        if (!lua_toboolean(L, 2)) {
+            flgs |= O_NOFOLLOW;
+        }
     }
     lua_settop(L, 1);
 
@@ -65,42 +79,42 @@ static int fstat_lua(lua_State *L)
     // set fields
     lua_createtable(L, 0, 14);
     // add descriptor
-    lauxh_pushint2tbl(L, "dev", buf.st_dev);
-    lauxh_pushint2tbl(L, "ino", buf.st_ino);
-    lauxh_pushint2tbl(L, "mode", buf.st_mode);
-    lauxh_pushint2tbl(L, "nlink", buf.st_nlink);
-    lauxh_pushint2tbl(L, "uid", buf.st_uid);
-    lauxh_pushint2tbl(L, "gid", buf.st_gid);
-    lauxh_pushint2tbl(L, "rdev", buf.st_rdev);
-    lauxh_pushint2tbl(L, "size", buf.st_size);
-    lauxh_pushint2tbl(L, "blksize", buf.st_blksize);
-    lauxh_pushint2tbl(L, "blocks", buf.st_blocks);
-    lauxh_pushint2tbl(L, "atime", buf.st_atime);
-    lauxh_pushint2tbl(L, "mtime", buf.st_mtime);
-    lauxh_pushint2tbl(L, "ctime", buf.st_ctime);
+    pushint2tbl(L, "dev", buf.st_dev);
+    pushint2tbl(L, "ino", buf.st_ino);
+    pushint2tbl(L, "mode", buf.st_mode);
+    pushint2tbl(L, "nlink", buf.st_nlink);
+    pushint2tbl(L, "uid", buf.st_uid);
+    pushint2tbl(L, "gid", buf.st_gid);
+    pushint2tbl(L, "rdev", buf.st_rdev);
+    pushint2tbl(L, "size", buf.st_size);
+    pushint2tbl(L, "blksize", buf.st_blksize);
+    pushint2tbl(L, "blocks", buf.st_blocks);
+    pushint2tbl(L, "atime", buf.st_atime);
+    pushint2tbl(L, "mtime", buf.st_mtime);
+    pushint2tbl(L, "ctime", buf.st_ctime);
     snprintf(perm, sizeof(perm), "%#o", buf.st_mode & 01777);
-    lauxh_pushstr2tbl(L, "perm", perm);
+    pushstr2tbl(L, "perm", perm);
     switch (buf.st_mode & S_IFMT) {
     case S_IFREG:
-        lauxh_pushstr2tbl(L, "type", "file");
+        pushstr2tbl(L, "type", "file");
         break;
     case S_IFDIR:
-        lauxh_pushstr2tbl(L, "type", "directory");
+        pushstr2tbl(L, "type", "directory");
         break;
     case S_IFLNK:
-        lauxh_pushstr2tbl(L, "type", "symlink");
+        pushstr2tbl(L, "type", "symlink");
         break;
     case S_IFCHR:
-        lauxh_pushstr2tbl(L, "type", "character_device");
+        pushstr2tbl(L, "type", "character_device");
         break;
     case S_IFBLK:
-        lauxh_pushstr2tbl(L, "type", "block_device");
+        pushstr2tbl(L, "type", "block_device");
         break;
     case S_IFSOCK:
-        lauxh_pushstr2tbl(L, "type", "socket");
+        pushstr2tbl(L, "type", "socket");
         break;
     case S_IFIFO:
-        lauxh_pushstr2tbl(L, "type", "fifo");
+        pushstr2tbl(L, "type", "fifo");
         break;
     }
 

--- a/src/getpid.c
+++ b/src/getpid.c
@@ -23,7 +23,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 // lua
-#include <lualib.h>
+#include <lua.h>
 
 static int getpid_lua(lua_State *L)
 {

--- a/src/nosigchld.c
+++ b/src/nosigchld.c
@@ -24,7 +24,6 @@
 #include <signal.h>
 #include <string.h>
 // lua
-#include <lauxlib.h>
 #include <lua.h>
 
 // Pure C no-op handler: async-signal-safe, never calls into Lua.

--- a/src/nosigpipe.c
+++ b/src/nosigpipe.c
@@ -20,7 +20,7 @@
  * IN THE SOFTWARE.
  **/
 
-#include <lualib.h>
+#include <lua.h>
 #include <signal.h>
 
 LUALIB_API int luaopen_testcase_nosigpipe(lua_State *L)

--- a/src/readdir.c
+++ b/src/readdir.c
@@ -24,8 +24,8 @@
 #include <errno.h>
 // lua
 #include <lauxlib.h>
-#include <lualib.h>
-// lua module
+#include <lua.h>
+// external library
 #include "lua_errno.h"
 
 static int readdir_lua(lua_State *L)

--- a/src/realpath.c
+++ b/src/realpath.c
@@ -27,7 +27,6 @@
 // lua
 #include <lauxlib.h>
 #include <lua.h>
-#include <lualib.h>
 // external library
 #include "lua_errno.h"
 

--- a/src/select.c
+++ b/src/select.c
@@ -20,7 +20,7 @@
  * IN THE SOFTWARE.
  */
 #include <lauxlib.h>
-#include <lualib.h>
+#include <lua.h>
 
 static int len_lua(lua_State *L)
 {

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -22,6 +22,9 @@
 #include <errno.h>
 #include <sys/socket.h>
 // lua
+#include <lauxlib.h>
+#include <lua.h>
+// external library
 #include "lauxhlib.h"
 #include "lua_errno.h"
 

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -20,13 +20,26 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 #include <errno.h>
+#include <stdio.h>
 #include <sys/socket.h>
+#include <unistd.h>
 // lua
 #include <lauxlib.h>
 #include <lua.h>
+#include <lualib.h>
 // external library
-#include "lauxhlib.h"
 #include "lua_errno.h"
+
+static inline FILE **checkfilep(lua_State *L, int idx)
+{
+#if LUA_VERSION_NUM >= 502
+    luaL_Stream *stream =
+        (luaL_Stream *)luaL_checkudata(L, idx, LUA_FILEHANDLE);
+    return &stream->f;
+#else
+    return (FILE **)luaL_checkudata(L, idx, LUA_FILEHANDLE);
+#endif
+}
 
 static int shutdown_lua(lua_State *L)
 {
@@ -42,7 +55,7 @@ static int shutdown_lua(lua_State *L)
     if (lua_isnumber(L, 1)) {
         fd = luaL_checkinteger(L, 1);
     } else {
-        FILE **fp = lauxh_checkfilep(L, 1);
+        FILE **fp = checkfilep(L, 1);
         if (*fp) {
             fd = fileno(*fp);
         }

--- a/src/socketpair.c
+++ b/src/socketpair.c
@@ -28,7 +28,7 @@
 #include <unistd.h>
 // lualib
 #include <lauxlib.h>
-#include <lualib.h>
+#include <lua.h>
 
 #define MODULE_MT "testcase.socketpair"
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -20,12 +20,13 @@
  * IN THE SOFTWARE.
  */
 #include <errno.h>
-#include <lauxlib.h>
-#include <lualib.h>
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+// lua
+#include <lauxlib.h>
+#include <lua.h>
 
 #define NSEC_IN_SEC 1000000000
 

--- a/src/xpcall.c
+++ b/src/xpcall.c
@@ -25,10 +25,6 @@
 
 static int xpcall_lua(lua_State *L)
 {
-    int top = lua_gettop(L);
-    int rc  = 0;
-    int ref = LUA_NOREF;
-
     luaL_checktype(L, 1, LUA_TFUNCTION);
     luaL_checktype(L, 2, LUA_TFUNCTION);
     lua_settop(L, 2);


### PR DESCRIPTION
This pull request introduces several improvements to the build system, testing workflow, and C source code organization for better maintainability, coverage reporting, and dependency management. The most significant changes are the addition of C code coverage reporting, modernization of the build and test workflows, and refactoring of C modules to remove deprecated dependencies and improve compatibility.

**CI/CD and Coverage Improvements:**

* Added a `covgen.sh` script and corresponding workflow steps to generate and upload C code coverage reports using `lcov`, and updated the Codecov action to v5 with OIDC authentication and explicit file selection (`.github/workflows/test.yml`, `covgen.sh`). [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R27-R29) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L50-R53) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R62-R72) [[4]](diffhunk://#diff-0c93c5c2694e970a8f83521eca1effbcbd2db3a96319f2ae1f21359b4a5e3bf8R1-R8)

* Updated the test workflow to set `TESTCASE_COVERAGE=1` during build, enabling coverage flags in compilation. ([.github/workflows/test.ymlL50-R53](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L50-R53), Feda6165L13R13)

**Build System Modernization:**

* Updated `rockspecs/testcase-scm-1.rockspec` to use `rockspec_format = "3.0"`, switch the build type to `hooks`, add `error` and `luarocks-build-hooks` as dependencies, and conditionally set coverage flags. [[1]](diffhunk://#diff-0eddadcf03a3eebae4797b36c5e5b3caef3adb6b9498c569c5242a80965e349eR1) [[2]](diffhunk://#diff-0eddadcf03a3eebae4797b36c5e5b3caef3adb6b9498c569c5242a80965e349eR16-R35)

* Refactored C module build definitions to specify `sources` and `incdirs` for modules that depend on external headers, improving dependency management and build reliability.

**C Source Code Refactoring and Compatibility:**

* Removed usage of deprecated or project-specific helper headers (e.g., `lauxhlib.h`) in favor of standard Lua C API, and implemented local helper functions where necessary (e.g., `checkfilep`, `pushint2tbl`, `pushstr2tbl`). Updated all affected modules accordingly (`src/close.c`, `src/fstat.c`, `src/shutdown.c`). [[1]](diffhunk://#diff-0904fa12743e9ff701b7ee1a16c4bfc632bf3998f36ceb022acf5d4bad26371dR23-R50) [[2]](diffhunk://#diff-8200a718e79eda398fb71bc660c3fcd2b8197c23e8b841523576cbf1b94c8e06L33-R46) [[3]](diffhunk://#diff-019f016ea8be68732f162d781bb409f6eb56493bac52defa1bc6e626e605943fR23-R43)

* Standardized Lua header includes across all C modules for consistency and compatibility with different Lua versions. [[1]](diffhunk://#diff-f0139d730b47a42c2d14242607b78f5efe714da5dc4940822c9475d097250713L32-R32) [[2]](diffhunk://#diff-e7e8e359747452cec466aef4059b251d6aa240e811b19add05a7ce73611226a3L26-R26) [[3]](diffhunk://#diff-f3db44e4835b398b83ea7168292bc524de0f5b309495c46e6bc5ad9cbe597e0dL23-R23) [[4]](diffhunk://#diff-f73c5f123976ecb31a430c371a6ed671d65820e9f8141f967bc16edc26b76d44L27-R28) [[5]](diffhunk://#diff-c7297c97296f7bfd715dba87bc7470e6318af996f93e3def4b25bb68655527cdL30) [[6]](diffhunk://#diff-a81a695ad8b5a69af392acb29f87f942ce878f4c7349731874190ce14a99d54dL23-R23) [[7]](diffhunk://#diff-81dbedd442c1a652f2724967f07044a13205439f438d44f787b4ab68cc1e7254L31-R31) [[8]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aL23-R29)

**Minor Enhancements and Fixes:**

* Added a `__tostring` metamethod to the process object in `src/fork.c` for improved debugging and introspection.

* Removed unused or unnecessary code in various modules (e.g., `src/xpcall.c`).

These changes collectively enhance the project's maintainability, test coverage visibility, and build robustness.