### PR TITLE
Refactor

### DIFF
--- a/rockspecs/testcase-scm-1.rockspec
+++ b/rockspecs/testcase-scm-1.rockspec
@@ -17,7 +17,7 @@ dependencies = {
     "errno >= 0.4.0",
 }
 build_dependencies = {
-    "luarocks-build-hooks >= 0.7.0",
+    "luarocks-build-hooks >= 0.8.0",
 }
 build = {
     type = "hooks",

--- a/src/chdir.c
+++ b/src/chdir.c
@@ -20,13 +20,13 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
-#include <errno.h>
-#include <unistd.h>
+// depend
+#include "lua_errno.h"
 // lua
 #include <lauxlib.h>
-#include <lua.h>
-// external library
-#include "lua_errno.h"
+// system
+#include <errno.h>
+#include <unistd.h>
 
 static int chdir_lua(lua_State *L)
 {

--- a/src/close.c
+++ b/src/close.c
@@ -19,15 +19,15 @@
  *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  *  DEALINGS IN THE SOFTWARE.
  */
+// depend
+#include "lua_errno.h"
+// lua
+#include <lauxlib.h>
+#include <lualib.h>
+// system
 #include <errno.h>
 #include <stdio.h>
 #include <unistd.h>
-// lua
-#include <lauxlib.h>
-#include <lua.h>
-#include <lualib.h>
-// external library
-#include "lua_errno.h"
 
 static inline FILE **checkfilep(lua_State *L, int idx)
 {

--- a/src/fork.c
+++ b/src/fork.c
@@ -20,6 +20,9 @@
  * IN THE SOFTWARE.
  */
 
+// lua
+#include <lauxlib.h>
+// system
 #include <errno.h>
 #include <signal.h>
 #include <stdlib.h>
@@ -27,9 +30,6 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
-// lua
-#include <lauxlib.h>
-#include <lua.h>
 
 #define PROC_MT "testcase.process"
 

--- a/src/fstat.c
+++ b/src/fstat.c
@@ -20,17 +20,17 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
+// depend
+#include "lua_errno.h"
+// lua
+#include <lauxlib.h>
+// system
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-// lua
-#include <lauxlib.h>
-#include <lua.h>
-// external library
-#include "lua_errno.h"
 
 static inline void pushint2tbl(lua_State *L, const char *k, lua_Integer v)
 {

--- a/src/getpid.c
+++ b/src/getpid.c
@@ -20,10 +20,11 @@
  * IN THE SOFTWARE.
  */
 
-#include <sys/types.h>
-#include <unistd.h>
 // lua
 #include <lua.h>
+// system
+#include <sys/types.h>
+#include <unistd.h>
 
 static int getpid_lua(lua_State *L)
 {

--- a/src/nosigchld.c
+++ b/src/nosigchld.c
@@ -20,11 +20,12 @@
  * IN THE SOFTWARE.
  */
 
+// lua
+#include <lua.h>
+// system
 #include <errno.h>
 #include <signal.h>
 #include <string.h>
-// lua
-#include <lua.h>
 
 // Pure C no-op handler: async-signal-safe, never calls into Lua.
 // sa_flags=0 (no SA_RESTART) means blocked syscalls like poll() return EINTR

--- a/src/nosigpipe.c
+++ b/src/nosigpipe.c
@@ -20,7 +20,9 @@
  * IN THE SOFTWARE.
  **/
 
+// lua
 #include <lua.h>
+// system
 #include <signal.h>
 
 LUALIB_API int luaopen_testcase_nosigpipe(lua_State *L)

--- a/src/readdir.c
+++ b/src/readdir.c
@@ -20,13 +20,13 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
-#include <dirent.h>
-#include <errno.h>
+// depend
+#include "lua_errno.h"
 // lua
 #include <lauxlib.h>
-#include <lua.h>
-// external library
-#include "lua_errno.h"
+// system
+#include <dirent.h>
+#include <errno.h>
 
 static int readdir_lua(lua_State *L)
 {

--- a/src/realpath.c
+++ b/src/realpath.c
@@ -20,15 +20,15 @@
  *  DEALINGS IN THE SOFTWARE.
  */
 
+// depend
+#include "lua_errno.h"
+// lua
+#include <lauxlib.h>
+// system
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <unistd.h>
-// lua
-#include <lauxlib.h>
-#include <lua.h>
-// external library
-#include "lua_errno.h"
 
 static size_t REALPATH_BUFSIZ = PATH_MAX;
 static char *REALPATH_BUF     = NULL;

--- a/src/select.c
+++ b/src/select.c
@@ -19,8 +19,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+// lua
 #include <lauxlib.h>
-#include <lua.h>
 
 static int len_lua(lua_State *L)
 {

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -19,16 +19,16 @@
  *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  *  DEALINGS IN THE SOFTWARE.
  */
+// depend
+#include "lua_errno.h"
+// lua
+#include <lauxlib.h>
+#include <lualib.h>
+// system
 #include <errno.h>
 #include <stdio.h>
 #include <sys/socket.h>
 #include <unistd.h>
-// lua
-#include <lauxlib.h>
-#include <lua.h>
-#include <lualib.h>
-// external library
-#include "lua_errno.h"
 
 static inline FILE **checkfilep(lua_State *L, int idx)
 {

--- a/src/signal.c
+++ b/src/signal.c
@@ -20,15 +20,15 @@
  * IN THE SOFTWARE.
  */
 
+// lua
+#include <lauxlib.h>
+// system
 #include <errno.h>
 #include <signal.h>
 #include <string.h>
 #include <strings.h>
 #include <sys/types.h>
 #include <unistd.h>
-// lua
-#include <lauxlib.h>
-#include <lua.h>
 
 typedef struct {
     const char *name;

--- a/src/socketpair.c
+++ b/src/socketpair.c
@@ -20,15 +20,15 @@
  * IN THE SOFTWARE.
  */
 
+// lua
+#include <lauxlib.h>
+// system
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-// lualib
-#include <lauxlib.h>
-#include <lua.h>
 
 #define MODULE_MT "testcase.socketpair"
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -19,14 +19,14 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+// lua
+#include <lauxlib.h>
+// system
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
-// lua
-#include <lauxlib.h>
-#include <lua.h>
 
 #define NSEC_IN_SEC 1000000000
 

--- a/src/xpcall.c
+++ b/src/xpcall.c
@@ -20,8 +20,8 @@
  * DEALINGS IN THE SOFTWARE.
  */
 // lua
+// lua
 #include <lauxlib.h>
-#include <lua.h>
 
 static int xpcall_lua(lua_State *L)
 {


### PR DESCRIPTION
This pull request refactors the C source files to standardize and clarify the order and grouping of `#include` directives, separating dependencies, Lua headers, and system headers more explicitly. It also updates a build dependency version in the rockspec file.

Dependency and build updates:

* Updated the `luarocks-build-hooks` build dependency version from `>= 0.7.0` to `>= 0.8.0` in `testcase-scm-1.rockspec` for improved compatibility or features.

Header organization and code clarity:

* Standardized the order of `#include` statements in all C source files to clearly separate dependency headers (such as `"lua_errno.h"`), Lua headers (like `<lauxlib.h>`), and system headers (like `<errno.h>`, `<unistd.h>`), improving code readability and maintainability. [[1]](diffhunk://#diff-9de5dbb5a5b5f48190a9d6d52252c2501f6fd7636f4deb723a8429c1188483c9L23-R29) [[2]](diffhunk://#diff-0904fa12743e9ff701b7ee1a16c4bfc632bf3998f36ceb022acf5d4bad26371dL22-R30) [[3]](diffhunk://#diff-f0139d730b47a42c2d14242607b78f5efe714da5dc4940822c9475d097250713R23-L32) [[4]](diffhunk://#diff-8200a718e79eda398fb71bc660c3fcd2b8197c23e8b841523576cbf1b94c8e06R23-L33) [[5]](diffhunk://#diff-e7e8e359747452cec466aef4059b251d6aa240e811b19add05a7ce73611226a3L23-R27) [[6]](diffhunk://#diff-08e79e39a1853dd5b4b084ecc06be272c9e42d446898e9d4e3d6c6d4f6ff8067R23-L27) [[7]](diffhunk://#diff-f3db44e4835b398b83ea7168292bc524de0f5b309495c46e6bc5ad9cbe597e0dR23-R25) [[8]](diffhunk://#diff-f73c5f123976ecb31a430c371a6ed671d65820e9f8141f967bc16edc26b76d44L23-R29) [[9]](diffhunk://#diff-c7297c97296f7bfd715dba87bc7470e6318af996f93e3def4b25bb68655527cdR23-L31) [[10]](diffhunk://#diff-a81a695ad8b5a69af392acb29f87f942ce878f4c7349731874190ce14a99d54dR22-L23) [[11]](diffhunk://#diff-019f016ea8be68732f162d781bb409f6eb56493bac52defa1bc6e626e605943fR22-L31) [[12]](diffhunk://#diff-ee884f815a1420da1fa11fde7e50cb66002645eacc4f62d4e58cfd24d0b9df0bR23-L31) [[13]](diffhunk://#diff-81dbedd442c1a652f2724967f07044a13205439f438d44f787b4ab68cc1e7254R23-L31) [[14]](diffhunk://#diff-340e9ee0d7971fa052b504957c48a3a313f76cb85490ff00afb3e9293d09f53aR22-L29) [[15]](diffhunk://#diff-2251c5b07e81b09188c404539f17c404f752df9a2a0f5d3597de8bd25b50801eR23-L24)

No functional changes were made to the logic of the modules; the changes are focused on code hygiene and maintainability.