### PR TITLE
Fix error masking when %s receives a non-string value

### DIFF
--- a/lib/printer.lua
+++ b/lib/printer.lua
@@ -32,15 +32,18 @@ local setmetatable = setmetatable
 local sub = string.sub
 local find = string.find
 local format = string.format
+local unpack = unpack or table.unpack
 local select_len = require('testcase.select').len
-local select_head = require('testcase.select').head
 local select_tail = require('testcase.select').tail
 -- constants
 local NEWLINE = '\r?\n'
 
-local function parse_format(s)
+local function parse_format(s, cb)
     if type(s) ~= 'string' then
         return 0
+    elseif cb ~= nil and type(cb) ~= 'function' then
+        error(format('invalid argument #2 (nil or function expected, got %s)',
+                     type(cb)), 2)
     end
 
     local len = #s
@@ -62,6 +65,11 @@ local function parse_format(s)
             if i - open > 1 then
                 -- found parameter '%<c> '
                 nparam = nparam + 1
+                if cb then
+                    -- notify the conversion specifier char and its 1-based
+                    -- argument offset
+                    cb(sub(s, open + 1, open + 1), nparam)
+                end
             end
             open = 0
         end
@@ -70,6 +78,9 @@ local function parse_format(s)
     if open > 0 then
         -- found specifier '%<c>'
         nparam = nparam + 1
+        if cb then
+            cb(sub(s, open + 1, open + 1), nparam)
+        end
     end
 
     return nparam
@@ -93,7 +104,19 @@ local function vstringify(doformat, s, ...)
 
         if nparam > 0 then
             narg = narg - nparam
-            local ok, res = pcall(format, s, select_head(nparam, ...))
+            -- pre-stringify the arguments corresponding to the 's' conversion
+            -- specifier so that string.format does not fail on non-string
+            -- values (e.g. an error table). this matches Lua 5.3+ behavior,
+            -- where '%s' implicitly applies tostring() to its argument.
+            parse_format(s, function(c, offset)
+                if c == 's' then
+                    local v = argv[offset + 1]
+                    if type(v) ~= 'string' then
+                        argv[offset + 1] = tostring(v)
+                    end
+                end
+            end)
+            local ok, res = pcall(format, s, unpack(argv, 2, nparam + 1))
             if not ok then
                 error(res, 3)
             end

--- a/test/printer_test.lua
+++ b/test/printer_test.lua
@@ -69,6 +69,28 @@ local function test_parse_format()
     }) do
         assert.equal(printer.parse_format(v.fmt), v.nparam)
     end
+
+    -- test that the optional callback receives each conversion specifier char
+    -- and its 1-based argument offset, and that the return value is unchanged
+    local seen = {}
+    local nparam = printer.parse_format('a %s b %q c %d', function(c, offset)
+        seen[#seen + 1] = c .. offset
+    end)
+    assert.equal(nparam, 3)
+    assert.equal(table.concat(seen, ','), 's1,q2,d3')
+
+    -- test that a trailing specifier (not terminated by a space) is reported
+    seen = {}
+    printer.parse_format('%q: %s', function(c, offset)
+        seen[#seen + 1] = c .. offset
+    end)
+    assert.equal(table.concat(seen, ','), 'q1,s2')
+
+    -- test that throws an error if the callback is not a function
+    local err = assert.throws(function()
+        printer.parse_format('%s', 'not-a-function')
+    end)
+    assert.match(err, 'invalid argument #2')
 end
 
 local function test_vstringify()
@@ -89,6 +111,23 @@ local function test_vstringify()
         printer.vstringify(true, 'foo %', 'bar', 1, true, false)
     end)
     assert.match(err, "invalid ")
+
+    -- test that pre-stringifies the '%s' argument with tostring() so a
+    -- non-string value (e.g. an error table) does not break string.format and
+    -- hide the real error (matches Lua 5.3+ behavior on Lua 5.1)
+    local errtbl = setmetatable({
+        type = 'EOPNOTSUPP',
+    }, {
+        __tostring = function(self)
+            return 'errno:' .. self.type
+        end,
+    })
+    assert.equal(printer.vstringify(true, 'failed: %q: %s', '/path', errtbl),
+                 'failed: "/path": errno:EOPNOTSUPP')
+
+    -- test that a raw non-string '%s' argument (no __tostring) is also
+    -- stringified with its default representation instead of raising an error
+    assert.match(printer.vstringify(true, 'got: %s', {}), 'got: table: 0x')
 end
 
 local function test_call_printline()


### PR DESCRIPTION
## Problem

On Lua 5.1, `string.format('%s', v)` raises an error when `v` is
neither a string nor has `__tostring`. When `testcase` fails to collect
test files, the error object is routed to a `%s` specifier (e.g. in
`bin/testcase.lua`), which makes `vstringify` re-throw the format error
via `error(res, 3)` and mask the original cause entirely.

## Fix

- Pre-stringify the arguments bound to a `%s` specifier in `vstringify`
  with `tostring()`, matching Lua 5.3+ behavior where `%s` implicitly
  applies `tostring()`. Other specifiers (`%d`, `%q`, `%f`, ...) are
  left untouched.
- `parse_format` gains an optional callback that reports each conversion
  specifier char and its 1-based argument offset; its return value
  (param count) is unchanged for backward compatibility.

## Test

- `luacheck .` clean and `lua ./test/testall.lua` passes.
- Added regression coverage in `test/printer_test.lua` for the `%s`
  non-string case and the new `parse_format` callback.