### PR TITLE
Add testcase.stat module backed by stat(2)/lstat(2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,31 @@ The stat table has the following fields:
 
 ---
 
+## stat, err = testcase.stat(pathname [, followsymlinks])
+
+Retrieves file status for the given path via `stat(2)` / `lstat(2)`.
+
+```lua
+local stat = require('testcase.stat')
+local info, err = stat('./foo/bar')
+```
+
+Unlike `testcase.fstat`, this calls `stat(2)` / `lstat(2)` directly instead of `open(2)` + `fstat(2)`, so it also succeeds on unix domain sockets, fifos and device special files. Prefer `testcase.stat` over `testcase.fstat` in new code.
+
+**Parameters**
+
+- `pathname:string`: Path to the file.
+- `followsymlinks:boolean`: Follow symbolic links via `stat(2)` when `true` (default). Use `lstat(2)` when `false`.
+
+**Returns**
+
+- `stat:table|nil`: Stat table on success, `nil` on failure.
+- `err:error|nil`: Error object on failure.
+
+The stat table has the same fields as `testcase.fstat` (see above).
+
+---
+
 ## pid = testcase.getpid()
 
 Returns the PID of the calling process.

--- a/lib/filesystem.lua
+++ b/lib/filesystem.lua
@@ -26,7 +26,7 @@ local match = string.match
 local sub = string.sub
 local trim_prefix = require('testcase.trim').prefix
 local trim_suffix = require('testcase.trim').suffix
-local fstat = require('testcase.fstat')
+local stat = require('testcase.stat')
 local readdir = require('testcase.readdir')
 local realpath = require('testcase.realpath')
 local pchdir = require('testcase.chdir')
@@ -59,7 +59,7 @@ local function walkdir(files, pathname, suffix)
         end
 
         local fullname = pathname .. '/' .. entry
-        local info, err = fstat(fullname)
+        local info, err = stat(fullname)
         if err then
             if err.type ~= ENOENT then
                 return err
@@ -97,7 +97,7 @@ local function getfiles(pathname, suffix)
     end
 
     local files = {}
-    local info, err = fstat(pathname)
+    local info, err = stat(pathname)
 
     if err then
         if err.type == ENOENT then
@@ -145,7 +145,7 @@ local function getstat(pathname)
     end
 
     -- luacheck: ignore err
-    local info, err = fstat(rpath, false)
+    local info, err = stat(rpath, false)
     -- failed to get stat
     if not info then
         return nil, err

--- a/rockspecs/testcase-scm-1.rockspec
+++ b/rockspecs/testcase-scm-1.rockspec
@@ -72,6 +72,13 @@ build = {
                 "$(DEP_ERROR_INCDIR)",
             },
         },
+        ["testcase.stat"] = {
+            sources = "src/stat.c",
+            incdirs = {
+                "$(DEP_ERRNO_INCDIR)",
+                "$(DEP_ERROR_INCDIR)",
+            },
+        },
         ["testcase.getpid"] = "src/getpid.c",
         ["testcase.nosigchld"] = "src/nosigchld.c",
         ["testcase.nosigpipe"] = "src/nosigpipe.c",

--- a/src/stat.c
+++ b/src/stat.c
@@ -1,0 +1,118 @@
+/**
+ *  Copyright (C) 2026 Masatoshi Fukunaga
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+
+// depend
+#include "lua_errno.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+static inline void pushint2tbl(lua_State *L, const char *k, lua_Integer v)
+{
+    lua_pushinteger(L, v);
+    lua_setfield(L, -2, k);
+}
+
+static inline void pushstr2tbl(lua_State *L, const char *k, const char *v)
+{
+    lua_pushstring(L, v);
+    lua_setfield(L, -2, k);
+}
+
+static int stat_lua(lua_State *L)
+{
+    const char *path   = luaL_checkstring(L, 1);
+    int followsymlinks = 1;
+    struct stat buf    = {0};
+    char perm[6]       = {0};
+
+    // followsymlinks option: default true
+    if (!lua_isnoneornil(L, 2)) {
+        luaL_checktype(L, 2, LUA_TBOOLEAN);
+        followsymlinks = lua_toboolean(L, 2);
+    }
+    lua_settop(L, 1);
+
+    // call stat(2) (follow symlinks) or lstat(2) directly. unlike the
+    // open()+fstat() approach used by testcase.fstat, these succeed on
+    // sockets, fifos and device special files.
+    if ((followsymlinks ? stat(path, &buf) : lstat(path, &buf)) == -1) {
+        lua_pushnil(L);
+        lua_errno_new(L, errno, "stat");
+        return 2;
+    }
+
+    // set fields
+    lua_createtable(L, 0, 14);
+    pushint2tbl(L, "dev", buf.st_dev);
+    pushint2tbl(L, "ino", buf.st_ino);
+    pushint2tbl(L, "mode", buf.st_mode);
+    pushint2tbl(L, "nlink", buf.st_nlink);
+    pushint2tbl(L, "uid", buf.st_uid);
+    pushint2tbl(L, "gid", buf.st_gid);
+    pushint2tbl(L, "rdev", buf.st_rdev);
+    pushint2tbl(L, "size", buf.st_size);
+    pushint2tbl(L, "blksize", buf.st_blksize);
+    pushint2tbl(L, "blocks", buf.st_blocks);
+    pushint2tbl(L, "atime", buf.st_atime);
+    pushint2tbl(L, "mtime", buf.st_mtime);
+    pushint2tbl(L, "ctime", buf.st_ctime);
+    snprintf(perm, sizeof(perm), "%#o", buf.st_mode & 01777);
+    pushstr2tbl(L, "perm", perm);
+    switch (buf.st_mode & S_IFMT) {
+    case S_IFREG:
+        pushstr2tbl(L, "type", "file");
+        break;
+    case S_IFDIR:
+        pushstr2tbl(L, "type", "directory");
+        break;
+    case S_IFLNK:
+        pushstr2tbl(L, "type", "symlink");
+        break;
+    case S_IFCHR:
+        pushstr2tbl(L, "type", "character_device");
+        break;
+    case S_IFBLK:
+        pushstr2tbl(L, "type", "block_device");
+        break;
+    case S_IFSOCK:
+        pushstr2tbl(L, "type", "socket");
+        break;
+    case S_IFIFO:
+        pushstr2tbl(L, "type", "fifo");
+        break;
+    }
+
+    return 1;
+}
+
+LUALIB_API int luaopen_testcase_stat(lua_State *L)
+{
+    lua_errno_loadlib(L);
+    lua_pushcfunction(L, stat_lua);
+    return 1;
+}

--- a/test/filesystem_test.lua
+++ b/test/filesystem_test.lua
@@ -43,6 +43,7 @@ local function test_getfiles()
         './test/shutdown_test.lua',
         './test/signal_test.lua',
         './test/socketpair_test.lua',
+        './test/stat_test.lua',
         './test/testcase_test.lua',
         './test/timer_test.lua',
     })

--- a/test/stat_test.lua
+++ b/test/stat_test.lua
@@ -1,0 +1,86 @@
+local assert = require('assert')
+local stat = require('testcase.stat')
+
+-- run a shell command and assert success. os.execute returns the exit code on
+-- Lua 5.1 / luajit (0 == success) and true/nil on 5.2 and later.
+local function cmd(s)
+    local ok = os.execute(s)
+    assert(ok == true or ok == 0,
+           'command failed: ' .. s .. ' (' .. tostring(ok) .. ')')
+end
+
+local function test_file()
+    local path = os.tmpname()
+    local f = assert(io.open(path, 'w'))
+    assert(f:write('hello'))
+    assert(f:close())
+
+    local info, err = stat(path)
+    assert(not err, err)
+    assert.equal(info.type, 'file')
+    assert.equal(info.size, 5)
+    assert.equal(type(info.perm), 'string')
+
+    os.remove(path)
+end
+
+local function test_directory()
+    local info, err = stat('./test')
+    assert(not err, err)
+    assert.equal(info.type, 'directory')
+end
+
+local function test_followsymlinks()
+    local target = os.tmpname()
+    local f = assert(io.open(target, 'w'))
+    assert(f:write('x'))
+    assert(f:close())
+
+    local link = target .. '.lnk'
+    os.remove(link)
+    cmd('ln -s ' .. target .. ' ' .. link)
+
+    -- omitted followsymlinks defaults to true: stat() follows the link
+    local info, err = stat(link)
+    assert(not err, err)
+    assert.equal(info.type, 'file')
+
+    -- explicit true follows the link
+    info, err = stat(link, true)
+    assert(not err, err)
+    assert.equal(info.type, 'file')
+
+    -- explicit false does not follow: lstat() reports the link itself
+    info, err = stat(link, false)
+    assert(not err, err)
+    assert.equal(info.type, 'symlink')
+
+    os.remove(link)
+    os.remove(target)
+end
+
+local function test_fifo()
+    -- regression: testcase.fstat (open + O_RDONLY) blocks on a fifo, but
+    -- stat()/lstat() succeeds and reports type == "fifo"
+    local path = os.tmpname()
+    os.remove(path)
+    cmd('mkfifo ' .. path)
+
+    local info, err = stat(path)
+    assert(not err, err)
+    assert.equal(info.type, 'fifo')
+
+    os.remove(path)
+end
+
+local function test_error()
+    local info, err = stat('./nonexistent_path_for_stat_test')
+    assert.is_nil(info)
+    assert(err, 'expected an error for a non-existent path')
+end
+
+test_file()
+test_directory()
+test_followsymlinks()
+test_fifo()
+test_error()

--- a/test/testall.lua
+++ b/test/testall.lua
@@ -16,6 +16,7 @@ for _, pathname in ipairs({
     'test/runner_test.lua',
     'test/shutdown_test.lua',
     'test/socketpair_test.lua',
+    'test/stat_test.lua',
     'test/testcase_test.lua',
     'test/timer_test.lua',
 }) do


### PR DESCRIPTION
## Problem

`testcase.fstat` retrieves file status with `open(2)` + `fstat(fd)`, which fails on unix sockets (macOS: `EOPNOTSUPP`), fifos (`open(O_RDONLY)` blocks) and some devices. This propagated through `lib/filesystem.lua`'s `walkdir` and aborted test collection whenever the tree contained such an entry (the symptom surfaced as the `%s` error masking fixed in #47).

## Change

- **New `src/stat.c`** (`testcase.stat`): calls `stat(2)` (default, follows symlinks) or `lstat(2)` (`followsymlinks=false`) directly. Unlike `fstat`, it succeeds on sockets/fifos/devices and reports their `type`. Returns the same stat table as `testcase.fstat`.
- **`lib/filesystem.lua`**: switched from `testcase.fstat` to `testcase.stat`. `walkdir` now skips non-file/non-directory entries by `type` instead of erroring.
- **`testcase.fstat` is kept unchanged** for backward compatibility.
- Added `test/stat_test.lua` (regular file / directory / symlink follow+nofollow / fifo regression / error) and registered it in `test/testall.lua`.
- Documented `testcase.stat` in `README.md`.

## Test

- `luacheck` clean (`lib/filesystem.lua`, `test/stat_test.lua`).
- CI: Lua 5.1/5.2/5.3/5.4 + luajit — `luarocks make` (builds `stat.c`) + `lua ./test/testall.lua`.
