### PR TITLE
Add testcase.rlimit module backed by getrlimit(2)/setrlimit(2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,43 @@ local path, err = realpath('./foo/bar')
 
 ---
 
+## rlim, err = testcase.rlimit(resource [, cur [, max]])
+
+Gets or sets resource limits via `getrlimit(2)` / `setrlimit(2)`.
+
+```lua
+local rlimit = require('testcase.rlimit')
+
+-- get the current limits
+local rlim, err = rlimit('nofile')
+
+-- lower the soft limit to 128, leaving the hard limit unchanged
+rlim, err = rlimit('nofile', 128)
+```
+
+**Parameters**
+
+- `resource:string`: One of `as`, `core`, `cpu`, `data`, `fsize`, `locks`, `memlock`, `msgqueue`, `nice`, `nofile`, `nproc`, `rss`, `rtprio`, `rttime`, `sigpending`, `stack`.
+- `cur:integer|nil`: New soft limit. Omitted or `nil` leaves it unchanged.
+- `max:integer|nil`: New hard limit. Omitted or `nil` leaves it unchanged. At least one of `cur` / `max` must be given when setting.
+
+`RLIM_INFINITY` is represented as `-1` in both the returned table and the `cur` / `max` arguments. Note that raising a hard limit usually requires privileges and fails with `EPERM` for unprivileged processes.
+
+**Returns**
+
+- `rlim:table|nil`: Rlimit table on success (see below), `nil` on failure. After a successful set, the limits are re-read with `getrlimit(2)`, so the returned values are the actual limits which may differ from the requested ones if the kernel clamped them.
+- `err:error|nil`: Error object on failure. Resources not supported by the platform fail with `ENOSYS`.
+
+The rlimit table has the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `resource` | string | Resource name |
+| `cur` | integer | Soft limit (`-1` for infinity) |
+| `max` | integer | Hard limit (`-1` for infinity) |
+
+---
+
 ## testcase.select
 
 Returns a table with three utility functions for variadic argument lists.

--- a/rockspecs/testcase-scm-1.rockspec
+++ b/rockspecs/testcase-scm-1.rockspec
@@ -96,6 +96,13 @@ build = {
                 "$(DEP_ERROR_INCDIR)",
             },
         },
+        ["testcase.rlimit"] = {
+            sources = "src/rlimit.c",
+            incdirs = {
+                "$(DEP_ERRNO_INCDIR)",
+                "$(DEP_ERROR_INCDIR)",
+            },
+        },
         ["testcase.select"] = "src/select.c",
         ["testcase.shutdown"] = {
             sources = "src/shutdown.c",

--- a/src/rlimit.c
+++ b/src/rlimit.c
@@ -1,0 +1,265 @@
+/**
+ *  Copyright (C) 2026 Masatoshi Fukunaga
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+
+// depend
+#include "lua_errno.h"
+// lua
+#include <lauxlib.h>
+// system
+#include <errno.h>
+#include <stdio.h>
+#include <sys/resource.h>
+#include <unistd.h>
+
+static const char *const RESOURCE_NAMES[] = {
+    "as",      "core",     "cpu",        "data",   "fsize", "locks",
+    "memlock", "msgqueue", "nice",       "nofile", "nproc", "rss",
+    "rtprio",  "rttime",   "sigpending", "stack",  NULL,
+};
+
+// returns the RLIMIT_* constant for the resource name at index 1, or -1 with
+// errno set to ENOSYS when the platform does not support the resource.
+static int check_rtype(lua_State *L, const char **name)
+{
+    int opt      = luaL_checkoption(L, 1, NULL, RESOURCE_NAMES);
+    int resource = -1;
+
+    *name = RESOURCE_NAMES[opt];
+    switch (opt) {
+    case 0: // as
+#ifdef RLIMIT_AS
+        resource = RLIMIT_AS;
+#endif
+        break;
+    case 1: // core
+#ifdef RLIMIT_CORE
+        resource = RLIMIT_CORE;
+#endif
+        break;
+    case 2: // cpu
+#ifdef RLIMIT_CPU
+        resource = RLIMIT_CPU;
+#endif
+        break;
+    case 3: // data
+#ifdef RLIMIT_DATA
+        resource = RLIMIT_DATA;
+#endif
+        break;
+    case 4: // fsize
+#ifdef RLIMIT_FSIZE
+        resource = RLIMIT_FSIZE;
+#endif
+        break;
+    case 5: // locks
+#ifdef RLIMIT_LOCKS
+        resource = RLIMIT_LOCKS;
+#endif
+        break;
+    case 6: // memlock
+#ifdef RLIMIT_MEMLOCK
+        resource = RLIMIT_MEMLOCK;
+#endif
+        break;
+    case 7: // msgqueue
+#ifdef RLIMIT_MSGQUEUE
+        resource = RLIMIT_MSGQUEUE;
+#endif
+        break;
+    case 8: // nice
+#ifdef RLIMIT_NICE
+        resource = RLIMIT_NICE;
+#endif
+        break;
+    case 9: // nofile
+#ifdef RLIMIT_NOFILE
+        resource = RLIMIT_NOFILE;
+#endif
+        break;
+    case 10: // nproc
+#ifdef RLIMIT_NPROC
+        resource = RLIMIT_NPROC;
+#endif
+        break;
+    case 11: // rss
+#ifdef RLIMIT_RSS
+        resource = RLIMIT_RSS;
+#endif
+        break;
+    case 12: // rtprio
+#ifdef RLIMIT_RTPRIO
+        resource = RLIMIT_RTPRIO;
+#endif
+        break;
+    case 13: // rttime
+#ifdef RLIMIT_RTTIME
+        resource = RLIMIT_RTTIME;
+#endif
+        break;
+    case 14: // sigpending
+#ifdef RLIMIT_SIGPENDING
+        resource = RLIMIT_SIGPENDING;
+#endif
+        break;
+    case 15: // stack
+#ifdef RLIMIT_STACK
+        resource = RLIMIT_STACK;
+#endif
+        break;
+    }
+
+    if (resource == -1) {
+        errno = ENOSYS;
+    }
+    return resource;
+}
+
+static int getlimit(lua_State *L, int resource, const char *resname,
+                    struct rlimit *rl)
+{
+    if (getrlimit(resource, rl) != 0) {
+        char msg[256] = {0};
+        snprintf(msg, sizeof(msg), "failed to getrlimit for resource '%s'",
+                 resname);
+
+        lua_pushnil(L);
+        lua_errno_new_with_message(L, errno, "getrlimit", msg);
+        return 2;
+    }
+    return 0;
+}
+
+// accepts -1 (RLIM_INFINITY) or a non-negative integer; any other negative
+// value raises an argument error.
+static int check_limit(lua_State *L, int idx, const char *resname,
+                       const char *field, rlim_t *limit)
+{
+    lua_Integer v = 0;
+
+    if (lua_isnoneornil(L, idx)) {
+        // if the argument is omitted or nil, leave the limit unchanged
+        return 0;
+    }
+
+    v = luaL_checkinteger(L, idx);
+    if (v < -1) {
+        // note: luaL_error format strings only accept lua_pushvfstring
+        // conversions, which reject the "%lld" conversion on lua 5.3+ and
+        // luaJIT; format the value with snprintf instead.
+        char msg[128] = {0};
+        snprintf(msg, sizeof(msg),
+                 "invalid %s for resource '%s': expected -1 (infinity) or a "
+                 "non-negative integer, got %lld",
+                 field, resname, (long long)v);
+        return luaL_argerror(L, idx, msg);
+    } else if (v == -1) {
+        *limit = RLIM_INFINITY;
+    } else {
+        *limit = (rlim_t)v;
+    }
+    return 1;
+}
+
+static int setlimit(lua_State *L, int resource, const char *resname,
+                    struct rlimit *rl)
+{
+    // if cur or max is specified, set the corresponding value in the
+    // rlimit struct and call setrlimit. omitted or nil means unchanged.
+    struct rlimit newrl = *rl;
+    int nspecified      = check_limit(L, 2, resname, "cur", &newrl.rlim_cur) +
+                          check_limit(L, 3, resname, "max", &newrl.rlim_max);
+    int rv              = 0;
+
+    if (!nspecified) {
+        // if neither cur nor max is specified, raise an error
+        return luaL_error(L, "either cur or max must be specified");
+    }
+
+    // if the new rlimit values are different from the current values,
+    // call setrlimit
+    if ((newrl.rlim_cur != rl->rlim_cur || newrl.rlim_max != rl->rlim_max) &&
+        setrlimit(resource, &newrl) != 0) {
+        char msg[256] = {0};
+        snprintf(msg, sizeof(msg), "failed to setrlimit for resource '%s'",
+                 resname);
+        lua_pushnil(L);
+        lua_errno_new_with_message(L, errno, "setrlimit", msg);
+        return 2;
+    }
+
+    // re-read the actual limits: the kernel may clamp the requested
+    // values (e.g. RLIMIT_NOFILE on darwin).
+    rv = getlimit(L, resource, resname, rl);
+    if (rv) {
+        return rv;
+    }
+
+    return 0;
+}
+
+static int rlimit_lua(lua_State *L)
+{
+    const char *resname = NULL;
+    int resource        = check_rtype(L, &resname);
+    struct rlimit rl    = {0};
+    int rv              = 0;
+
+    if (resource == -1) {
+        char msg[256] = {0};
+        snprintf(msg, sizeof(msg),
+                 "resource '%s' is not supported on this platform", resname);
+        lua_pushnil(L);
+        lua_errno_new_with_message(L, ENOSYS, "getrlimit", msg);
+        return 2;
+    }
+
+    rv = getlimit(L, resource, resname, &rl);
+    if (rv) {
+        // early return if getlimit failed
+        return rv;
+    }
+
+    // if cur or max is specified, call setlimit to update the limits
+    if (lua_gettop(L) > 1 && (rv = setlimit(L, resource, resname, &rl))) {
+        // early return if setlimit failed
+        return rv;
+    }
+
+    // RLIM_INFINITY is reported as -1
+    lua_createtable(L, 0, 3);
+    lua_pushstring(L, resname);
+    lua_setfield(L, -2, "resource");
+    lua_pushinteger(L, rl.rlim_cur == RLIM_INFINITY ? -1 :
+                                                      (lua_Integer)rl.rlim_cur);
+    lua_setfield(L, -2, "cur");
+    lua_pushinteger(L, rl.rlim_max == RLIM_INFINITY ? -1 :
+                                                      (lua_Integer)rl.rlim_max);
+    lua_setfield(L, -2, "max");
+    return 1;
+}
+
+LUALIB_API int luaopen_testcase_rlimit(lua_State *L)
+{
+    lua_errno_loadlib(L);
+    lua_pushcfunction(L, rlimit_lua);
+    return 1;
+}

--- a/test/filesystem_test.lua
+++ b/test/filesystem_test.lua
@@ -39,6 +39,7 @@ local function test_getfiles()
         './test/iohook_test.lua',
         './test/printer_test.lua',
         './test/registry_test.lua',
+        './test/rlimit_test.lua',
         './test/runner_test.lua',
         './test/shutdown_test.lua',
         './test/signal_test.lua',

--- a/test/rlimit_test.lua
+++ b/test/rlimit_test.lua
@@ -1,0 +1,160 @@
+local assert = require('assert')
+local errno = require('errno')
+local rlimit = require('testcase.rlimit')
+
+-- all resource names accepted by rlimit()
+local RESOURCE_NAMES = {
+    'as',
+    'core',
+    'cpu',
+    'data',
+    'fsize',
+    'locks',
+    'memlock',
+    'msgqueue',
+    'nice',
+    'nofile',
+    'nproc',
+    'rss',
+    'rtprio',
+    'rttime',
+    'sigpending',
+    'stack',
+}
+
+-- a limit is either -1 (RLIM_INFINITY) or a non-negative integer
+local function islimit(v)
+    return v == -1 or (v >= 0 and math.floor(v) == v)
+end
+
+local function test_get()
+    local rlim, err = rlimit('nofile')
+    assert(not err, err)
+    assert(rlim, 'expected a rlimit table')
+    assert.equal(rlim.resource, 'nofile')
+    assert(islimit(rlim.cur), 'cur must be -1 or a non-negative integer')
+    assert(islimit(rlim.max), 'max must be -1 or a non-negative integer')
+    if rlim.cur ~= -1 and rlim.max ~= -1 then
+        assert(rlim.cur <= rlim.max, 'cur must not exceed max')
+    end
+end
+
+local function test_get_all_resources()
+    -- every known resource name either returns its limits or fails with
+    -- ENOSYS when the platform does not support it
+    for _, name in ipairs(RESOURCE_NAMES) do
+        local rlim, err = rlimit(name)
+        if rlim then
+            assert.equal(rlim.resource, name)
+            assert(islimit(rlim.cur), name .. ': invalid cur')
+            assert(islimit(rlim.max), name .. ': invalid max')
+        else
+            assert.equal(err.type, errno.ENOSYS)
+        end
+    end
+end
+
+local function test_set_cur()
+    local orig, err = rlimit('nofile')
+    assert(not err, err)
+    assert(orig, 'expected a rlimit table')
+
+    -- lower the soft limit to 16 (well below any usable limit), then restore
+    local newcur = (orig.cur ~= -1 and orig.cur <= 16) and orig.cur or 16
+    local rlim, e = rlimit('nofile', newcur)
+    assert(not e, e)
+    assert(rlim, 'expected a rlimit table')
+    assert.equal(rlim.resource, 'nofile')
+    assert.equal(rlim.cur, newcur)
+    -- the hard limit must be unchanged
+    assert.equal(rlim.max, orig.max)
+
+    -- the getter must observe the new value
+    rlim, e = rlimit('nofile')
+    assert(not e, e)
+    assert.equal(rlim.cur, newcur)
+
+    -- restore the original soft limit (always allowed: cur <= max)
+    rlim, e = rlimit('nofile', orig.cur)
+    assert(not e, e)
+    assert.equal(rlim.cur, orig.cur)
+    assert.equal(rlim.max, orig.max)
+end
+
+local function test_set_infinity()
+    -- -1 is a valid argument meaning RLIM_INFINITY; it must never raise an
+    -- argument error
+    local orig, err = rlimit('nofile')
+    assert(not err, err)
+
+    local ok, rlim, e = pcall(rlimit, 'nofile', -1)
+    assert(ok, 'must not raise an argument error for -1')
+    if rlim then
+        -- raising the soft limit up to the hard limit succeeded
+        assert.equal(rlim.cur, -1)
+        assert.equal(rlim.max, orig.max)
+        -- restore the original soft limit
+        local restored, e2 = rlimit('nofile', orig.cur)
+        assert(not e2, e2)
+        assert.equal(restored.cur, orig.cur)
+    else
+        -- raising the soft limit beyond a finite hard limit fails with EINVAL
+        assert.equal(e.type, errno.EINVAL)
+        -- the failed setrlimit must not change the current limits
+        local cur, e2 = rlimit('nofile')
+        assert(not e2, e2)
+        assert.equal(cur.cur, orig.cur)
+    end
+end
+
+local function test_cur_gt_max()
+    local orig, err = rlimit('nofile')
+    assert(not err, err)
+
+    if orig.max ~= -1 then
+        -- a soft limit above the hard limit is rejected with EINVAL
+        local rlim, e = rlimit('nofile', orig.max + 1)
+        assert.is_nil(rlim)
+        assert(e, 'expected an error for cur > max')
+        assert.equal(e.type, errno.EINVAL)
+        -- limits must be unchanged after the failed setrlimit
+        rlim, e = rlimit('nofile')
+        assert(not e, e)
+        assert.equal(rlim.cur, orig.cur)
+        assert.equal(rlim.max, orig.max)
+    end
+end
+
+local function test_invalid_resource()
+    local ok, err = pcall(rlimit, 'unknown_resource')
+    assert(not ok, 'expected an error for an unknown resource')
+    assert.match(err, 'unknown_resource')
+end
+
+local function test_no_limits_specified()
+    local ok, err = pcall(rlimit, 'nofile', nil)
+    assert(not ok, 'expected an error when neither cur nor max is specified')
+    assert.match(err, 'either cur or max must be specified')
+
+    ok = pcall(rlimit, 'nofile', nil, nil)
+    assert(not ok, 'expected an error when neither cur nor max is specified')
+end
+
+local function test_negative_limits()
+    local ok, err = pcall(rlimit, 'nofile', -2)
+    assert(not ok, 'expected an error for a negative cur')
+    assert.match(err, 'invalid cur')
+
+    ok, err = pcall(rlimit, 'nofile', nil, -100)
+    assert(not ok, 'expected an error for a negative max')
+    assert.match(err, 'invalid max')
+end
+
+test_get()
+test_get_all_resources()
+test_set_cur()
+test_set_infinity()
+test_cur_gt_max()
+test_invalid_resource()
+test_no_limits_specified()
+test_negative_limits()

--- a/test/testall.lua
+++ b/test/testall.lua
@@ -13,6 +13,7 @@ for _, pathname in ipairs({
     'test/iohook_test.lua',
     'test/printer_test.lua',
     'test/registry_test.lua',
+    'test/rlimit_test.lua',
     'test/runner_test.lua',
     'test/shutdown_test.lua',
     'test/socketpair_test.lua',


### PR DESCRIPTION
## Problem

There was no portable way to get or set resource limits from test code: tests that needed to verify `EMFILE`/`ENFILE` behaviour or constrain a child process had to shell out or skip the scenario.

## Change

- **New `src/rlimit.c`** (`testcase.rlimit`): single `rlimit(resource[, cur[, max]])` function backed by `getrlimit(2)` / `setrlimit(2)`. Returns a `{resource, cur, max}` table.
  - `RLIM_INFINITY` is reported and accepted as `-1` in both directions.
  - Omitted or `nil` `cur` / `max` leaves the corresponding limit unchanged.
  - Resource names not supported by the platform fail with `ENOSYS` instead of rejecting the option name, so the same resource list works across platforms.
  - After a successful `setrlimit(2)`, the limits are re-read so the returned values are the actual limits, which the kernel may clamp (e.g. `RLIMIT_NOFILE` on darwin).
- Registered the module in `rockspecs/testcase-scm-1.rockspec` and `test/testall.lua`.
- Added `test/rlimit_test.lua` (get on all resources / set soft limit / infinity round-trip / `cur > max` / argument errors / `ENOSYS`).
- Documented `testcase.rlimit` in `README.md`.

